### PR TITLE
Zero pad the day to match the expected value from the word list

### DIFF
--- a/wordle.py
+++ b/wordle.py
@@ -8,7 +8,7 @@ BLACK = '⬛'
 
 def get_daily():
     now = datetime.datetime.now()
-    month, day, year = now.strftime("%b"), str(now.day), str(now.year)
+    month, day, year = now.strftime("%b"), str(now.day).zfill(2), str(now.year)
 
     with open(os.path.join('resources', 'wordle_key.csv'), newline='') as f:
         reader = csv.reader(f, delimiter=',')


### PR DESCRIPTION
The bot failed to play today's word, logs and debugging led me to the word scanner which was checking for Mar 1, 2022 while the record in the resource was Mar 01, 2022.

This change adds the zero padding to the date in order to match the expected format.