### PR TITLE
Refresh the day's word at game start

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,6 +62,7 @@ if __name__ == '__main__':
                     "6 guesses remaining."
 
         )
+        wordle.get_daily()
         await bot.api.send_markdown_message(room.room_id, response)
         s.save_state(state)
 


### PR DESCRIPTION
New games may end up using yesterday's word, refresh the day's word at the start of a game.